### PR TITLE
Required socket - To Avoid uninitialized constant FigNewton::Missing::Socket (NameError)

### DIFF
--- a/lib/fig_newton/missing.rb
+++ b/lib/fig_newton/missing.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'socket'
 
 module FigNewton
   module Missing


### PR DESCRIPTION
When using FigNewton without other common gems (active_record, composite_keys, ...etc ), when reading the file Socket has not been required yet. I added the require to the missing module.
