### PR TITLE
Allow Booleans as permissible return values from YML

### DIFF
--- a/config/yaml/test_config.yml
+++ b/config/yaml/test_config.yml
@@ -8,5 +8,8 @@ first:
   second:
     third: foo
     fourth: bar
+    fifth: true
+    sixth: false
 
 port: 1234
+use_ssl: false

--- a/features/fig_newton.feature
+++ b/features/fig_newton.feature
@@ -9,12 +9,12 @@ Feature: Functionality of the fig_newton gem
     Given I have read the configuration file
     When I ask for a value that does not exist named "does_not_exist"
     Then I should raise a NoMethodError exception
-    
+
   Scenario: Getting the default filename from an environment variable
     Given I have an environment variable named "FIG_NEWTON_FILE" set to "sample.yml"
     When I ask for the value for "from_the_env_file"
     Then I should see "read from the env file"
-    
+
   Scenario: Using a file that has the same name as the hostname
     Given I have a yml file that is named after the hostname
     When I ask for the value for "from_the_hostname_file"
@@ -34,16 +34,23 @@ Feature: Functionality of the fig_newton gem
     And I ask for the node value for "second"
     Then the "third" value for the node should be "foo"
     And the "fourth" value for the node should be "bar"
+    And the "fifth" value for the node should be true
+    And the "sixth" value for the node should be false
 
   Scenario: Using default directory and file
     Given I have read the default file from the default directory
     When I ask for the value for "base_url"
     Then I should see "http://cheezyworld.com"
-    
+
   Scenario:  Requesting a numerical value
     Given I have read the configuration file
     When I ask for the value for "port"
     Then I should see 1234
+
+  Scenario:  Requesting a boolean value
+    Given I have read the configuration file
+    When I ask for the value for "use_ssl"
+    Then I should see false
 
   Scenario:  Requesting data from a node can be converted to a hash
     Given I have read the configuration file
@@ -57,18 +64,28 @@ Feature: Functionality of the fig_newton gem
     Given I have read the configuration file
     When I ask for a value that does not exist named "does_not_exist" that has a default value "the default value"
     Then I should see "the default value"
-  
+
+  Scenario: Requesting data that does not exist but has a default value of true should return the default value of true
+    Given I have read the configuration file
+    When I ask for a value that does not exist named "does_not_exist" that has a default value true
+    Then I should see true
+
+  Scenario: Requesting data that does not exist but has a default value of false should return the default value of false
+    Given I have read the configuration file
+    When I ask for a value that does not exist named "does_not_exist" that has a default value false
+    Then I should see false
+
   Scenario: Requesting data that does not exist but has a default block should return the block result
     Given I have read the configuration file
     When I ask for a value that does not exist named "does_not_exist" that has a default block returning "the default value"
     Then I should see "the default value"
-  
+
   Scenario: Requesting data that does not exist but has a default lambda should return the lambda result
     Given I have read the configuration file
     When I ask for a value that does not exist named "does_not_exist" that has a default lambda returning "the default value"
     Then I should see "the default value"
     And the lambda should be passed the property "does_not_exist"
-    
+
   Scenario: Requesting data that does not exist but has a default proc should return the proc result
     Given I have read the configuration file
     When I ask for a value that does not exist named "does_not_exist" that has a default proc returning "the default value"

--- a/features/step_definitions/fig_newton_steps.rb
+++ b/features/step_definitions/fig_newton_steps.rb
@@ -19,12 +19,20 @@ Then /^I should see (\d+)$/ do |value|
   @value.should == value.to_i
 end
 
+Then /^I should see true$/ do
+  @value.should == true
+end
+
+Then /^I should see false$/ do
+  @value.should == false
+end
+
 When /^I ask for a value that does not exist named "([^\"]*)"$/ do |non_existing|
   @does_not_exist = non_existing
 end
 
 Then /^I should raise a NoMethodError exception$/ do
-  expect{ FigNewton.send(@does_not_exist) }.to raise_error(NoMethodError) 
+  expect{ FigNewton.send(@does_not_exist) }.to raise_error(NoMethodError)
 end
 
 Then /^I should have a node$/ do
@@ -33,6 +41,14 @@ end
 
 Then /^the "([^\"]*)" value for the node should be "([^\"]*)"$/ do |key, value|
   @value.send(key).should == value
+end
+
+Then /^the "([^\"]*)" value for the node should be true$/ do |key|
+  @value.send(key).should == true
+end
+
+Then /^the "([^\"]*)" value for the node should be false$/ do |key|
+  @value.send(key).should == false
 end
 
 When /^I ask for the node value for "([^\"]*)"$/ do |key|
@@ -65,10 +81,18 @@ When(/^I ask for a value that does not exist named "(.+)" that has a default val
   @value = FigNewton.send key, value
 end
 
+When(/^I ask for a value that does not exist named "(.+)" that has a default value true$/) do |key|
+  @value = FigNewton.send key, true
+end
+
+When(/^I ask for a value that does not exist named "(.+)" that has a default value false$/) do |key|
+  @value = FigNewton.send key, false
+end
+
 When(/^I ask for a value that does not exist named "(.+)" that has a default block returning "(.+)"$/) do |key, value|
   @value = FigNewton.send(key) {
     value
-  }    
+  }
 end
 
 When(/^I ask for a value that does not exist named "(.+)" that has a default lambda returning "(.+)"$/) do |key, value|
@@ -78,7 +102,7 @@ end
 
 When(/^I ask for a value that does not exist named "(.+)" that has a default proc returning "(.+)"$/) do |key, value|
   myproc = Proc.new {value}
-  @value = FigNewton.send(key, &myproc)  
+  @value = FigNewton.send(key, &myproc)
 end
 
 Then(/^the lambda should be passed the property "(.+)"$/) do |expected_property|

--- a/lib/fig_newton/missing.rb
+++ b/lib/fig_newton/missing.rb
@@ -7,6 +7,7 @@ module FigNewton
       read_file unless @yml
       m = args.first
       value = @yml[m.to_s]
+      return value if type_bool?(value)
       value = args[1] unless value
       value = block.call(m.to_s) unless value or block.nil?
       super unless value
@@ -21,14 +22,18 @@ module FigNewton
         hostname = Socket.gethostname
         hostfile = "#{yml_directory}/#{hostname}.yml"
         @yml = YAML.load_file hostfile if File.exist? hostfile
-      end 
+      end
       FigNewton.load('default.yml') if @yml.nil?
     end
 
     private
-    
+
     def type_known?(value)
        value.kind_of? String or value.kind_of? Integer
+    end
+
+    def type_bool?(value)
+      value.is_a?(TrueClass) || value.is_a?(FalseClass)
     end
   end
 end


### PR DESCRIPTION
Given a local.yml that looks like this:

```
    base_url:  http://system_test.mycompany.com
    use_ssl: false
```

This will allow us to call:
```ruby
FigNewton.use_ssl
# => false
```

Without this change we get the following:
```ruby
FigNewton.use_ssl
# => undefined method `use_ssl' for #<FigNewton::Node:0x007fbd754c9408>
```