### PR TITLE
Multiple env files

### DIFF
--- a/config/yaml/env_file_one.yml
+++ b/config/yaml/env_file_one.yml
@@ -1,0 +1,1 @@
+from_the_env_file_one: read from the merge one

--- a/config/yaml/env_file_two.yml
+++ b/config/yaml/env_file_two.yml
@@ -1,0 +1,1 @@
+from_the_env_file_two: read from the merge two

--- a/features/fig_newton.feature
+++ b/features/fig_newton.feature
@@ -14,7 +14,14 @@ Feature: Functionality of the fig_newton gem
     Given I have an environment variable named "FIG_NEWTON_FILE" set to "sample.yml"
     When I ask for the value for "from_the_env_file"
     Then I should see "read from the env file"
-    
+
+  Scenario: Merging various environment files
+    Given I have an environment variable named "FIG_NEWTON_FILE" set to a comma separated list with the filenames "env_file_one.yml" and "env_file_two.yml"
+    When I ask for the value for "from_the_env_file_one"
+    Then I should see "read from the merge one"
+    And I ask for the value for "from_the_env_file_two"
+    And I should see "read from the merge two"
+
   Scenario: Using a file that has the same name as the hostname
     Given I have a yml file that is named after the hostname
     When I ask for the value for "from_the_hostname_file"

--- a/features/step_definitions/fig_newton_steps.rb
+++ b/features/step_definitions/fig_newton_steps.rb
@@ -50,7 +50,7 @@ end
 Given (/^I have an environment variable named "([^\"]*)" set to "([^\"]*)"$/) do |env_name, filename|
   FigNewton.yml = nil
   ENV[env_name] = filename
-  FigNewton.yml_directory = 'config/yaml'
+  FigNewton.yml_directory = 'config/yaml'  
   FigNewton.instance_variable_set(:@yml, nil)
 end
 
@@ -93,3 +93,9 @@ Then (/^the lambda should be passed the property "(.+)"$/) do |expected_property
   expect(@lambda_property).to eq(expected_property)
 end
 
+Given(/^I have an environment variable named "(.*?)" set to a comma separated list with the filenames "(.*?)" and "(.*?)"$/) do |env_name, filename1, filename2|
+  FigNewton.yml = nil
+  ENV[env_name] = "#{filename1},#{filename2}"
+  FigNewton.yml_directory = 'config/yaml'
+  FigNewton.instance_variable_set(:@yml, nil)
+end

--- a/lib/fig_newton/missing.rb
+++ b/lib/fig_newton/missing.rb
@@ -16,7 +16,15 @@ module FigNewton
 
     def read_file
       @yml = nil
-      @yml = YAML.load_file "#{yml_directory}/#{ENV['FIG_NEWTON_FILE']}" if ENV['FIG_NEWTON_FILE']
+
+      if ENV['FIG_NEWTON_FILE']
+        files_to_read = env_files
+
+        @yml = files_to_read.inject({}) do |total_merge,file|
+          total_merge.merge!(YAML.load_file "#{yml_directory}/#{file}")
+        end
+      end
+
       unless @yml
         hostname = Socket.gethostname
         hostfile = "#{yml_directory}/#{hostname}.yml"
@@ -26,6 +34,11 @@ module FigNewton
     end
 
     private
+
+    def env_files
+      content = ENV['FIG_NEWTON_FILE']
+      content.include?(',') ? content.split(',') : [content]
+    end
 
     def type_known?(value)
       known_types = [String, Integer, TrueClass, FalseClass]


### PR DESCRIPTION
Hello,

This is a humble contribution as my first pull request in GitHub.

With this feature, the user should be able to specify a list of files residing in the yml_directory through FIG_NEWTON_FILE, as follows:
FIG_NEWTON_FILE = "production.yml, portuguese.yml"
and the resulting loaded information will include a merge of both files, so different combinations for environment configs can be applied.

The main intention of this feature is to make the user able to combine environment files with language files (local/testing/production + English/Spanish/Portuguese, as it is a common use when developing applications with support for various languages.

This way, it is not necessary to repeat language data in every environment file.

Hope this helps,
Please let me know your feedback.

Thanks.